### PR TITLE
Improvements for Result tool tip

### DIFF
--- a/ProcessKiller/Main.cs
+++ b/ProcessKiller/Main.cs
@@ -36,6 +36,7 @@ public class Main : IPlugin, IPluginI18n, ISettingProvider, IReloadable, IDispos
 			PluginOptionType= PluginAdditionalOption.AdditionalOptionType.Checkbox,
 			Key = ShowCommandLine,
 			DisplayLabel = Resources.plugin_setting_show_command_line,
+			DisplayDescription = plugin_setting_show_command_line_description,
 		}
 	];
 
@@ -67,7 +68,7 @@ public class Main : IPlugin, IPluginI18n, ISettingProvider, IReloadable, IDispos
 					TitleHighlightData = pr.MatchData,
 					Score = pr.Score,
 					ContextData = p.ProcessName,
-					ToolTipData = new ToolTipData(p.ProcessName, pr.CommandLine),
+					ToolTipData = new ToolTipData(p.ProcessName, pr.GetToolTipText(_showCommandLine)),
 					Action = c =>
 					{
 						ProcessHelper.TryKill(p);

--- a/ProcessKiller/Main.cs
+++ b/ProcessKiller/Main.cs
@@ -36,7 +36,7 @@ public class Main : IPlugin, IPluginI18n, ISettingProvider, IReloadable, IDispos
 			PluginOptionType= PluginAdditionalOption.AdditionalOptionType.Checkbox,
 			Key = ShowCommandLine,
 			DisplayLabel = Resources.plugin_setting_show_command_line,
-			DisplayDescription = plugin_setting_show_command_line_description,
+			DisplayDescription = Resources.plugin_setting_show_command_line_description,
 		}
 	];
 
@@ -68,7 +68,7 @@ public class Main : IPlugin, IPluginI18n, ISettingProvider, IReloadable, IDispos
 					TitleHighlightData = pr.MatchData,
 					Score = pr.Score,
 					ContextData = p.ProcessName,
-					ToolTipData = new ToolTipData(p.ProcessName, pr.GetToolTipText(_showCommandLine)),
+					ToolTipData = new ToolTipData($"{p.ProcessName} - {p.Id}", pr.GetToolTipText(_showCommandLine)),
 					Action = c =>
 					{
 						ProcessHelper.TryKill(p);

--- a/ProcessKiller/ProcessResult.cs
+++ b/ProcessKiller/ProcessResult.cs
@@ -1,3 +1,4 @@
+using Community.PowerToys.Run.Plugin.ProcessKiller.Properties;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -56,6 +57,17 @@ internal class ProcessResult
 		Process = process;
 		Score = 0;
 		Path = TryGetProcessFilename(process);
+	}
+
+	public string GetToolTipText(bool showCommandLine) {
+		string text = $"{Resources.plugin_tool_tip_main_window}: {Process.MainWindowTitle}\n{Resources.plugin_tool_tip_path}: {Process.Path}"
+
+		if (showCommandLine)
+		{
+			text = text + $"\n{Resources.plugin_tool_tip_command_line}: {CommandLine}"
+		}
+
+		return text
 	}
 
 	private static string TryGetProcessFilename(Process p)

--- a/ProcessKiller/ProcessResult.cs
+++ b/ProcessKiller/ProcessResult.cs
@@ -60,7 +60,7 @@ internal class ProcessResult
 	}
 
 	public string GetToolTipText(bool showCommandLine)
-{
+	{
 		string text = $"{Resources.plugin_tool_tip_main_window}: {Process.MainWindowTitle}\n{Resources.plugin_tool_tip_path}: {Path}"
 
 		if (showCommandLine)

--- a/ProcessKiller/ProcessResult.cs
+++ b/ProcessKiller/ProcessResult.cs
@@ -59,8 +59,9 @@ internal class ProcessResult
 		Path = TryGetProcessFilename(process);
 	}
 
-	public string GetToolTipText(bool showCommandLine) {
-		string text = $"{Resources.plugin_tool_tip_main_window}: {Process.MainWindowTitle}\n{Resources.plugin_tool_tip_path}: {Process.Path}"
+	public string GetToolTipText(bool showCommandLine)
+{
+		string text = $"{Resources.plugin_tool_tip_main_window}: {Process.MainWindowTitle}\n{Resources.plugin_tool_tip_path}: {Path}"
 
 		if (showCommandLine)
 		{

--- a/ProcessKiller/ProcessResult.cs
+++ b/ProcessKiller/ProcessResult.cs
@@ -61,14 +61,22 @@ internal class ProcessResult
 
 	public string GetToolTipText(bool showCommandLine)
 	{
-		string text = $"{Resources.plugin_tool_tip_main_window}: {Process.MainWindowTitle}\n{Resources.plugin_tool_tip_path}: {Path}"
+		List<string> textLines = new List<string>();
 
-		if (showCommandLine)
+		if (!string.IsNullOrWhiteSpace(Process.MainWindowTitle))
 		{
-			text = text + $"\n{Resources.plugin_tool_tip_command_line}: {CommandLine}"
+			textLines.Add($"{Resources.plugin_tool_tip_main_window}:\n  {Process.MainWindowTitle}");
+		}
+		if (!string.IsNullOrWhiteSpace(Path))
+		{
+			textLines.Add($"{Resources.plugin_tool_tip_path}:\n  {Path}");
+		}
+		if (showCommandLine && !string.IsNullOrWhiteSpace(CommandLine))
+		{
+			textLines.Add($"{Resources.plugin_tool_tip_command_line}:\n  {CommandLine}");
 		}
 
-		return text
+		return string.Join("\n", textLines);
 	}
 
 	private static string TryGetProcessFilename(Process p)

--- a/ProcessKiller/Properties/Resources.Designer.cs
+++ b/ProcessKiller/Properties/Resources.Designer.cs
@@ -115,11 +115,47 @@ namespace Community.PowerToys.Run.Plugin.ProcessKiller.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show command line of the process, this makes the plugin slower..
+        ///   Looks up a localized string similar to Show command line of the process in the tool tip.
         /// </summary>
         internal static string plugin_setting_show_command_line {
             get {
                 return ResourceManager.GetString("plugin_setting_show_command_line", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This may slow down the plugin..
+        /// </summary>
+        internal static string plugin_setting_show_command_line_description {
+            get {
+                return ResourceManager.GetString("plugin_setting_show_command_line_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path.
+        /// </summary>
+        internal static string plugin_tool_tip_path {
+            get {
+                return ResourceManager.GetString("plugin_tool_tip_path", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Main window.
+        /// </summary>
+        internal static string plugin_tool_tip_main_window {
+            get {
+                return ResourceManager.GetString("plugin_tool_tip_main_window", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Command line.
+        /// </summary>
+        internal static string plugin_tool_tip_command_line {
+            get {
+                return ResourceManager.GetString("plugin_tool_tip_command_line", resourceCulture);
             }
         }
     }

--- a/ProcessKiller/Properties/Resources.Designer.cs
+++ b/ProcessKiller/Properties/Resources.Designer.cs
@@ -133,16 +133,16 @@ namespace Community.PowerToys.Run.Plugin.ProcessKiller.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Path.
+        ///   Looks up a localized string similar to Command Line.
         /// </summary>
-        internal static string plugin_tool_tip_path {
+        internal static string plugin_tool_tip_command_line {
             get {
-                return ResourceManager.GetString("plugin_tool_tip_path", resourceCulture);
+                return ResourceManager.GetString("plugin_tool_tip_command_line", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Main window.
+        ///   Looks up a localized string similar to Main Window.
         /// </summary>
         internal static string plugin_tool_tip_main_window {
             get {
@@ -151,11 +151,11 @@ namespace Community.PowerToys.Run.Plugin.ProcessKiller.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Command line.
+        ///   Looks up a localized string similar to Path.
         /// </summary>
-        internal static string plugin_tool_tip_command_line {
+        internal static string plugin_tool_tip_path {
             get {
-                return ResourceManager.GetString("plugin_tool_tip_command_line", resourceCulture);
+                return ResourceManager.GetString("plugin_tool_tip_path", resourceCulture);
             }
         }
     }

--- a/ProcessKiller/Properties/Resources.de-DE.resx
+++ b/ProcessKiller/Properties/Resources.de-DE.resx
@@ -148,6 +148,6 @@
     <value>Hauptfenster</value>
   </data>
   <data name="plugin_tool_tip_command_line" xml:space="preserve">
-    <value>Kommandozeile</value>
+    <value>Befehlszeile</value>
   </data>
 </root>

--- a/ProcessKiller/Properties/Resources.de-DE.resx
+++ b/ProcessKiller/Properties/Resources.de-DE.resx
@@ -135,4 +135,19 @@
   <data name="plugin_setting_kill_all_count" xml:space="preserve">
     <value>Mindestanzahl an Treffer, damit "Alle Instanzen beenden" angezeigt wird</value>
   </data>
+  <data name="plugin_setting_show_command_line" xml:space="preserve">
+    <value>Befehlszeile des Prozesses im Tooltip anzeigen.</value>
+  </data>
+  <data name="plugin_setting_show_command_line_description" xml:space="preserve">
+    <value>Dies kann das Plugin verlangsamen.</value>
+  </data>
+  <data name="plugin_tool_tip_path" xml:space="preserve">
+    <value>Pfad</value>
+  </data>
+  <data name="plugin_tool_tip_main_window" xml:space="preserve">
+    <value>Hauptfenster</value>
+  </data>
+  <data name="plugin_tool_tip_command_line" xml:space="preserve">
+    <value>Kommandozeile</value>
+  </data>
 </root>

--- a/ProcessKiller/Properties/Resources.resx
+++ b/ProcessKiller/Properties/Resources.resx
@@ -136,6 +136,18 @@
     <value>Minimun matches to show "Kill all instances"</value>
   </data>
   <data name="plugin_setting_show_command_line" xml:space="preserve">
-    <value>Show command line of the process, this makes the plugin slower.</value>
+    <value>Show command line of the process in the tool tip</value>
+  </data>
+  <data name="plugin_setting_show_command_line_description" xml:space="preserve">
+    <value>This may slow down the plugin.</value>
+  </data>
+  <data name="plugin_tool_tip_path" xml:space="preserve">
+    <value>Path</value>
+  </data>
+  <data name="plugin_tool_tip_main_window" xml:space="preserve">
+    <value>Main window</value>
+  </data>
+  <data name="plugin_tool_tip_command_line" xml:space="preserve">
+    <value>Command line</value>
   </data>
 </root>

--- a/ProcessKiller/Properties/Resources.resx
+++ b/ProcessKiller/Properties/Resources.resx
@@ -145,9 +145,9 @@
     <value>Path</value>
   </data>
   <data name="plugin_tool_tip_main_window" xml:space="preserve">
-    <value>Main window</value>
+    <value>Main Window</value>
   </data>
   <data name="plugin_tool_tip_command_line" xml:space="preserve">
-    <value>Command line</value>
+    <value>Command Line</value>
   </data>
 </root>


### PR DESCRIPTION
This PR implements the following features and changes related to the result tool tip:
1. Improved settings name and description including the German translation.
2. Support for showing path and main window title in tool tip.
3. Improved tool tip layout and showing command line only if it is enabled.

New tool tip layout (replacing the command line value):
```
Main window: xxxxx
Path: xxxxxx
Command line: xxxx
```

### How was this tested
Unfortunately I have not enough disk space to test it yet and can not test it locally on my system. Please test everything before merging this in.